### PR TITLE
Add cache refresh & unify logic

### DIFF
--- a/cli/display/life_index/cli_life_index.cpp
+++ b/cli/display/life_index/cli_life_index.cpp
@@ -12,11 +12,6 @@ void showLifeIndices(ConfigContext& cft,I18n& i18n) {
     auto configUser = cft.user();
     WeatherManager manager(configKey.getHFApiKey(), configKey.getHFHost(), configUser.getLanguage());
 
-    // 强制刷新缓存
-    CacheManager cacheManager(configUser.getConfigJson());
-    cacheManager.clearAllCache();  // 清除所有缓存
-
-
     // 初次加载（尝试用缓存）
     auto result = manager.getLifeIndices(configUser.getCityId(), configUser.getCacheExpiry("weather_index"));
 

--- a/core/CacheManager.cpp
+++ b/core/CacheManager.cpp
@@ -30,7 +30,6 @@ void CacheManager::setCache(const std::string& key, const std::string& value, in
 }
 
 
-// 获取缓存数据：带过期检查，过期则删除并返回空
 std::string CacheManager::getCache(const std::string& key) {
     auto it = cache.find(key);
     if (it != cache.end()) {
@@ -47,12 +46,6 @@ std::string CacheManager::getCache(const std::string& key) {
     }
     return "";
 }
-
-// 设置缓存数据：记录时间戳（支持指定过期时间，默认使用配置）
-struct CacheEntry {
-    std::string data;
-    std::chrono::system_clock::time_point timestamp; // 使用system_clock
-};
 
 // 清除所有缓存
 void CacheManager::clearAllCache() {


### PR DESCRIPTION
## Summary
- fix `CacheManager` duplicate struct definition
- remove cache clearing from life index view
- allow lunar info view to refresh and show source

## Testing
- `cmake ..`
- `cmake --build .` *(fails: fatal error: conio.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6854db6e9b10832a93a014428913bf7c