### PR TITLE
Introduce HttpClient and central DoubaoManager

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,6 +78,8 @@ set(WEATHER_GLOBAL
         config/config_key.h
         config/base_config.cpp
         config/base_config.h
+        utils/http_client.cpp
+        utils/http_client.h
 )
 
 

--- a/cli/context_builder/buildAISuggestionContent.cpp
+++ b/cli/context_builder/buildAISuggestionContent.cpp
@@ -2,7 +2,7 @@
 #include <iostream>
 #include <string>
 #include "config_context.h"
-#include "doubao_helper.h"
+#include "../core/doubao_manager.h"
 #include "weather_manager.h"
 #include "common/cli_context.h"
 
@@ -35,6 +35,7 @@ std::string buildAISuggestionContent(CliContext& cli) {
             << "------------------------\n";
     }
     std::cout << "\t🌟 " << cli.i18n.tr("ai_suggestion", "loading") << "\n";
-    auto suggestion = callDoubaoAI(configKey.getDoubaoKey(), configKey.getDoubaoEndpoint(), oss.str());
+    DoubaoManager doubao(configKey.getDoubaoKey(), configKey.getDoubaoEndpoint());
+    auto suggestion = doubao.getAdvice(oss.str());
     return suggestion;
 }

--- a/cli/display/ai_advisor/cli_ai_advisor.cpp
+++ b/cli/display/ai_advisor/cli_ai_advisor.cpp
@@ -6,7 +6,6 @@
 
 #include <iostream>
 
-#include "doubao_helper.h"
 #include "weather_manager.h"
 #include "../common/cli_clear_console.h"
 #include "common/cli_context.h"

--- a/cli/display/date_display/cli_date_display.cpp
+++ b/cli/display/date_display/cli_date_display.cpp
@@ -6,7 +6,7 @@
 #include <iostream>
 #include <conio.h>
 
-#include "doubao_translator.h"
+#include "../../../core/doubao_manager.h"
 #include "lunar_api.h"
 #include "../../../core/CacheManager.h"
 #include "../../common/cli_clear_console.h"
@@ -93,7 +93,8 @@ void showCurrentDate(CliContext& ctx, bool showAll) {
                 std::cout << lunarInfo;
                 std::cout << "\nWaiting for translation..." << std::endl;
 
-                lunarInfo = translateWithDoubao(lunarInfo, "English", configKey);
+                DoubaoManager doubao(configKey.getDoubaoKey(), configKey.getDoubaoEndpoint());
+                lunarInfo = doubao.translate(lunarInfo, "English");
 
                 clearConsole();
                 std::cout << (fromCache ? "(来自缓存)" : "(来自网络)") << std::endl;

--- a/core/doubao_manager.cpp
+++ b/core/doubao_manager.cpp
@@ -1,5 +1,44 @@
-//
-// Created by 13033 on 2025/6/16.
-//
-
 #include "doubao_manager.h"
+
+using json = nlohmann::json;
+
+DoubaoManager::DoubaoManager(std::string token, std::string endpoint)
+    : token(std::move(token)), endpointId(std::move(endpoint)) {}
+
+std::string DoubaoManager::request(const std::string& systemPrompt, const std::string& userPrompt) {
+    json payload = {
+        {"model", endpointId},
+        {"messages", {
+            {{"role", "system"}, {"content", systemPrompt}},
+            {{"role", "user"}, {"content", userPrompt}}
+        }}
+    };
+
+    std::string body = payload.dump();
+    std::string response;
+    std::vector<std::string> headers = {
+        "Authorization: Bearer " + token,
+        "Content-Type: application/json"
+    };
+    if (!HttpClient::post("https://ark.cn-beijing.volces.com/api/v3/chat/completions", body, response, headers)) {
+        return "";
+    }
+    try {
+        auto j = json::parse(response);
+        if (j.contains("choices") && !j["choices"].empty()) {
+            return j["choices"][0]["message"]["content"].get<std::string>();
+        }
+    } catch (...) {
+    }
+    return "";
+}
+
+std::string DoubaoManager::translate(const std::string& text, const std::string& targetLang) {
+    std::string prompt = "请将以下内容翻译为" + targetLang + "：\n" + text;
+    return request("You are a helpful assistant.", prompt);
+}
+
+std::string DoubaoManager::getAdvice(const std::string& prompt) {
+    std::string sys = "你是一个生活助手，擅长为用户提供生活建议。请用不超过100字的一段话返回 不要使用markdown格式，用\\n表示换行 每行不超过20字";
+    return request(sys, prompt);
+}

--- a/core/doubao_manager.h
+++ b/core/doubao_manager.h
@@ -1,16 +1,15 @@
-//
-// Created by 13033 on 2025/6/16.
-//
+#pragma once
+#include <string>
+#include "../utils/http_client.h"
+#include "../utils/json.hpp"
 
-#ifndef DOUBAO_MANAGER_H
-#define DOUBAO_MANAGER_H
-
-
-
-class doubao_manager {
-
+class DoubaoManager {
+public:
+    DoubaoManager(std::string token, std::string endpoint);
+    std::string translate(const std::string& text, const std::string& targetLang);
+    std::string getAdvice(const std::string& prompt);
+private:
+    std::string token;
+    std::string endpointId;
+    std::string request(const std::string& systemPrompt, const std::string& userPrompt);
 };
-
-
-
-#endif //DOUBAO_MANAGER_H

--- a/main_cli.cpp
+++ b/main_cli.cpp
@@ -22,9 +22,8 @@
 #include "i18n/i18n_loader.h"
 #include "lunar_api.h"
 #include "config/config_key.h"
-#include "doubao_translator.h"
 #include "date_utils.h"  // 包含辅助函数头文件
-#include "doubao_helper.h"  // 调用豆包函数
+#include "core/doubao_manager.h"
 #include "core/CacheManager.h"
 
 

--- a/utils/doubao_helper.cpp
+++ b/utils/doubao_helper.cpp
@@ -1,68 +1,7 @@
 #include "doubao_helper.h"
-#include <curl/curl.h>
-#include <json.hpp>
-#include <iostream>
-
-using json = nlohmann::json;
-
-static size_t WriteCallback(char* ptr, size_t size, size_t nmemb, std::string* output) {
-    output->append(ptr, size * nmemb);
-    return size * nmemb;
-}
+#include "../core/doubao_manager.h"
 
 std::string callDoubaoAI(const std::string& token, const std::string& endpointId, const std::string& fullPrompt) {
-    // 初始化 CURL
-    CURL* curl = curl_easy_init();
-    if (!curl) {
-        return "[CURL 初始化失败]";
-    }
-
-    std::string response;
-
-    // 构建请求体
-    json payload = {
-        {"model", endpointId},
-        {"messages", {
-            {{"role", "system"}, {"content", "你是一个生活助手，擅长为用户提供生活建议。请用不超过100字的一段话返回 不要使用markdown格式，用\\n表示换行 每行不超过20字"}},
-            {{"role", "user"}, {"content", fullPrompt}}
-        }}
-    };
-
-    std::string body = payload.dump();
-
-    // 构建请求头
-    struct curl_slist* headers = nullptr;
-    headers = curl_slist_append(headers, ("Authorization: Bearer " + token).c_str());
-    headers = curl_slist_append(headers, "Content-Type: application/json");
-
-    // 设置 CURL 选项
-    curl_easy_setopt(curl, CURLOPT_URL, "https://ark.cn-beijing.volces.com/api/v3/chat/completions");
-    curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
-    curl_easy_setopt(curl, CURLOPT_POSTFIELDS, body.c_str());
-    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, WriteCallback);
-    curl_easy_setopt(curl, CURLOPT_WRITEDATA, &response);
-    curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 0L);  // 忽略 SSL 验证
-    curl_easy_setopt(curl, CURLOPT_ACCEPT_ENCODING, "gzip");
-
-    // 执行请求
-    CURLcode res = curl_easy_perform(curl);
-    curl_slist_free_all(headers);
-    curl_easy_cleanup(curl);
-
-    if (res != CURLE_OK) {
-        return "[网络请求失败: " + std::string(curl_easy_strerror(res)) + "]";
-    }
-
-    // 解析响应
-    try {
-        json j = json::parse(response);
-        if (j.contains("choices") && j["choices"].is_array() && j["choices"].size() > 0) {
-            // 只返回 AI 的建议内容
-            return j["choices"][0]["message"]["content"].get<std::string>();
-        } else {
-            return "[AI 响应格式不正确]";
-        }
-    } catch (const std::exception& e) {
-        return "[解析响应失败] 错误信息: " + std::string(e.what());
-    }
+    DoubaoManager mgr(token, endpointId);
+    return mgr.getAdvice(fullPrompt);
 }

--- a/utils/doubao_translator.cpp
+++ b/utils/doubao_translator.cpp
@@ -1,29 +1,16 @@
-#include <curl/curl.h>
-#include <json.hpp>
-#include <fstream>
-#include <iostream>
-#include "../config/config_key.h"
 #include "doubao_translator.h"
-#include "../core/weather_manager.h"
+#include "../core/doubao_manager.h"
+#include <iostream>
 
-
-using json = nlohmann::json;
-
-static size_t WriteCallback(void* contents, size_t size, size_t nmemb, std::string* output) {
-    size_t totalSize = size * nmemb;
-    output->append((char*)contents, totalSize);
-    return totalSize;
-}
 void translateLunarDataIfEnglish(LunarData& data, const std::string& lang, const ConfigKey& configKey) {
     if (lang != "en") return;
-
+    DoubaoManager mgr(configKey.getDoubaoKey(), configKey.getDoubaoEndpoint());
     auto t = [&](std::string& field) {
         if (!field.empty()) {
-            std::string translated = translateWithDoubao(field, "英文", configKey);
+            std::string translated = mgr.translate(field, "英文");
             if (!translated.empty()) field = translated;
         }
     };
-
     t(data.festivals);
     t(data.yi);
     t(data.ji);
@@ -32,61 +19,6 @@ void translateLunarDataIfEnglish(LunarData& data, const std::string& lang, const
 }
 
 std::string translateWithDoubao(const std::string& text, const std::string& targetLang, const ConfigKey& configKey) {
-    std::string apiKey = configKey.getDoubaoKey();
-    std::string endpointId = configKey.getDoubaoEndpoint();
-
-    if (apiKey.empty() || endpointId.empty()) {
-        std::cerr << "❌ Doubao 配置缺失。" << std::endl;
-        return text;
-    }
-
-    // 拼接翻译提示词
-    std::string prompt = "请将以下内容翻译为" + targetLang + "：\n" + text;
-
-    // 构造请求 JSON
-    json payload = {
-        {"model", endpointId},
-        {"messages", {
-            {{"role", "system"}, {"content", "You are a helpful assistant. 请在json字串中每个值前加入\\t"}},
-            {{"role", "user"}, {"content", prompt}}
-        }}
-    };
-
-    std::string response;
-    CURL* curl = curl_easy_init();
-    if (!curl) return text;
-
-    struct curl_slist* headers = nullptr;
-    headers = curl_slist_append(headers, "Content-Type: application/json");
-    headers = curl_slist_append(headers, ("Authorization: Bearer " + apiKey).c_str());
-
-    curl_easy_setopt(curl, CURLOPT_URL, "https://ark.cn-beijing.volces.com/api/v3/chat/completions");
-    curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
-    std::string body = payload.dump();
-    curl_easy_setopt(curl, CURLOPT_POSTFIELDS, body.c_str());
-    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, WriteCallback);
-    curl_easy_setopt(curl, CURLOPT_WRITEDATA, &response);
-    curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 0L); // 可选
-    curl_easy_setopt(curl, CURLOPT_ACCEPT_ENCODING, "gzip");
-
-    CURLcode res = curl_easy_perform(curl);
-    curl_slist_free_all(headers);
-    curl_easy_cleanup(curl);
-
-    if (res != CURLE_OK) {
-        std::cerr << "❌ Doubao 请求失败: " << curl_easy_strerror(res) << std::endl;
-        return text;
-    }
-
-    // 解析返回内容
-    try {
-        auto j = json::parse(response);
-        if (j.contains("choices")) {
-            return j["choices"][0]["message"]["content"];
-        }
-    } catch (...) {
-        std::cerr << "❌ 返回 JSON 解析失败" << std::endl;
-    }
-
-    return text;
+    DoubaoManager mgr(configKey.getDoubaoKey(), configKey.getDoubaoEndpoint());
+    return mgr.translate(text, targetLang);
 }

--- a/utils/doubao_translator.h
+++ b/utils/doubao_translator.h
@@ -4,8 +4,6 @@
 #include "lunar_api.h"
 #include "../core/weather_manager.h"
 
-
-
 // 翻译函数声明（传入文本和 configKey）
 std::string translateWithDoubao(const std::string& text, const std::string& targetLang, const ConfigKey& configKey);
 void translateLunarDataIfEnglish(LunarData& data, const std::string& lang, const ConfigKey& configKey);

--- a/utils/http_client.cpp
+++ b/utils/http_client.cpp
@@ -1,0 +1,55 @@
+#include "http_client.h"
+#include <utility>
+
+size_t HttpClient::writeCallback(char* ptr, size_t size, size_t nmemb, void* userdata) {
+    std::string* str = static_cast<std::string*>(userdata);
+    str->append(ptr, size * nmemb);
+    return size * nmemb;
+}
+
+static void applyHeaders(CURL* curl, struct curl_slist*& headerList, const std::vector<std::string>& headers) {
+    for (const auto& h : headers) {
+        headerList = curl_slist_append(headerList, h.c_str());
+    }
+    if (headerList) {
+        curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headerList);
+    }
+}
+
+bool HttpClient::get(const std::string& url, std::string& response,
+                     const std::vector<std::string>& headers) {
+    CURL* curl = curl_easy_init();
+    if (!curl) return false;
+    struct curl_slist* headerList = nullptr;
+    applyHeaders(curl, headerList, headers);
+    curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
+    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writeCallback);
+    curl_easy_setopt(curl, CURLOPT_WRITEDATA, &response);
+    curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 0L);
+    curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 0L);
+    curl_easy_setopt(curl, CURLOPT_ACCEPT_ENCODING, "gzip");
+    CURLcode res = curl_easy_perform(curl);
+    curl_slist_free_all(headerList);
+    curl_easy_cleanup(curl);
+    return res == CURLE_OK;
+}
+
+bool HttpClient::post(const std::string& url, const std::string& body,
+                      std::string& response,
+                      const std::vector<std::string>& headers) {
+    CURL* curl = curl_easy_init();
+    if (!curl) return false;
+    struct curl_slist* headerList = nullptr;
+    applyHeaders(curl, headerList, headers);
+    curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
+    curl_easy_setopt(curl, CURLOPT_POSTFIELDS, body.c_str());
+    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writeCallback);
+    curl_easy_setopt(curl, CURLOPT_WRITEDATA, &response);
+    curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 0L);
+    curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 0L);
+    curl_easy_setopt(curl, CURLOPT_ACCEPT_ENCODING, "gzip");
+    CURLcode res = curl_easy_perform(curl);
+    curl_slist_free_all(headerList);
+    curl_easy_cleanup(curl);
+    return res == CURLE_OK;
+}

--- a/utils/http_client.h
+++ b/utils/http_client.h
@@ -1,0 +1,15 @@
+#pragma once
+#include <string>
+#include <vector>
+#include <curl/curl.h>
+
+class HttpClient {
+public:
+    static bool get(const std::string& url, std::string& response,
+                    const std::vector<std::string>& headers = {});
+    static bool post(const std::string& url, const std::string& body,
+                     std::string& response,
+                     const std::vector<std::string>& headers = {});
+private:
+    static size_t writeCallback(char* ptr, size_t size, size_t nmemb, void* userdata);
+};

--- a/utils/ip_locator.cpp
+++ b/utils/ip_locator.cpp
@@ -1,29 +1,14 @@
 #include "ip_locator.h"
 #include "json.hpp"  // nlohmann/json
-#include <curl/curl.h>
 #include <sstream>
 #include <iostream>
+#include "http_client.h"
 
 using json = nlohmann::json;
 
-static size_t WriteCallback(void* contents, size_t size, size_t nmemb, void* userp) {
-    ((std::string*)userp)->append((char*)contents, size * nmemb);
-    return size * nmemb;
-}
-
 Location getLocationByIP() {
-    CURL* curl;
-    CURLcode res;
     std::string readBuffer;
-
-    curl = curl_easy_init();
-    if (curl) {
-        curl_easy_setopt(curl, CURLOPT_URL, "http://ip-api.com/json/");
-        curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, WriteCallback);
-        curl_easy_setopt(curl, CURLOPT_WRITEDATA, &readBuffer);
-        res = curl_easy_perform(curl);
-        curl_easy_cleanup(curl);
-    }
+    HttpClient::get("http://ip-api.com/json/", readBuffer);
 
     Location loc;
     try {

--- a/utils/lunar_api.h
+++ b/utils/lunar_api.h
@@ -26,4 +26,4 @@ std::string callLunarApi(std::string apikey);
 LunarData parseLunarJson(const std::string& jsonStr);
 std::string formatLunarInfo(const LunarData& d, I18n& i18n);
 
-void printLunarData(const LunarData& d);
+void printLunarData(const LunarData& d, const std::string& lang, const ConfigKey& configKey, const I18n& i18n);


### PR DESCRIPTION
## Summary
- add reusable `HttpClient` for cURL operations
- implement `DoubaoManager` using the new network layer
- refactor lunar API, Doubao helpers and translator to use `DoubaoManager`
- update CLI displays to rely on `DoubaoManager`
- switch IP lookup to `HttpClient`

## Testing
- `cmake -S . -B build` *(fails: file COPY cannot find `configKey.json`)*

------
https://chatgpt.com/codex/tasks/task_e_6855593d9458832a9aa961514b45357a