### PR TITLE
Fix unit switching and AI prompt units

### DIFF
--- a/src/cli/context_builder/buildAISuggestionContent.cpp
+++ b/src/cli/context_builder/buildAISuggestionContent.cpp
@@ -27,10 +27,14 @@ std::string buildAISuggestionContent(CliContext& cli) {
 
     // 构造 AI Prompt
     std::ostringstream oss;
+    std::string unit = configUser.getUnits();
+    bool imperial = (unit == "imperial" || unit == "i");
+    std::string tempUnit = imperial ? "℉" : "℃";
     oss << "请你用" << configUser.getLanguage() << "语言回答:现在用户所在城市是 "
-        << configUser.getCityId() << "，当前气温为 " << weather.tempMax
-        << "，天气状况为 " << weather.textDay << "，风速为 " << weather.windDirDay
-        << "，湿度为 " << weather.humidity << "。\n";
+        << configUser.getCityId() << "，当前气温为 " << weather.tempMax << tempUnit
+        << "，天气状况为 " << weather.textDay << "，风向为 " << weather.windDirDay
+        << "，风力为 " << weather.windScaleDay
+        << "，湿度为 " << weather.humidity << "%。请使用以上单位给出生活建议。\n";
 
     for (const auto& idx : lifeIndex.indices) {
         oss << "📅 " << idx.date << "\n"

--- a/src/cli/display/weather_display/cli_weather_display.cpp
+++ b/src/cli/display/weather_display/cli_weather_display.cpp
@@ -76,10 +76,11 @@ void displayWeather(ForecastResult &result, I18n &i18n, ConfigUser &configUser, 
 
     printLine();
 
-    std::string tempUnit = unit == "i" ? i18n.tr("forecast", "temp_unit_f")
-                                        : i18n.tr("forecast", "temp_unit_c");
-    std::string precipUnit = unit == "i" ? i18n.tr("forecast", "precip_unit_in")
-                                          : i18n.tr("forecast", "precip_unit_mm");
+    bool imperial = (unit == "i" || unit == "imperial");
+    std::string tempUnit = imperial ? i18n.tr("forecast", "temp_unit_f")
+                                    : i18n.tr("forecast", "temp_unit_c");
+    std::string precipUnit = imperial ? i18n.tr("forecast", "precip_unit_in")
+                                      : i18n.tr("forecast", "precip_unit_mm");
 
     std::string tempHeader = i18n.tr("forecast", "temperature") + "(" + tempUnit + ")";
     std::string precipHeader = i18n.tr("forecast", "precip") + "(" + precipUnit + ")";


### PR DESCRIPTION
## Summary
- correct unit check when rendering forecast table headers
- include unit symbol in AI suggestion prompt

## Testing
- `cmake -B build -S .` *(fails: cannot find `configs/configKey.json`)*

------
https://chatgpt.com/codex/tasks/task_e_68556f47cae8832a84cb57cfbbf91a75