### PR TITLE
Add GUI wrapper for CLI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,8 @@ project(weatherForecast)
 # 设置当前项目的名称为 WeatherApp
 
 set(CMAKE_CXX_STANDARD 20)
-# 设置 C++ 标准为 C++17
+find_package(Qt5 COMPONENTS Widgets REQUIRED)
+# 设置 C++ 标准为 C++20
 
 set(CURL_PATH "F:\\CPlusDependences\\LibCurl\\V8")
 
@@ -67,6 +68,12 @@ set(CLI_SOURCES
         ${SRC_ROOT}/cli/common/cli_context.h
 
 )
+set(GUI_SOURCES
+        ${SRC_ROOT}/gui/main_gui.cpp
+        ${SRC_ROOT}/gui/mainwindow.cpp
+        ${SRC_ROOT}/gui/mainwindow.h
+        ${SRC_ROOT}/gui/mainwindow.ui
+)
 set(WEATHER_GLOBAL
         ${SRC_ROOT}/core/weather_manager.cpp          # 天气核心实现
         ${SRC_ROOT}/cli/display/update_city/cli_update_city.cpp
@@ -106,6 +113,12 @@ if(WIN32)
     )
 endif()
 
+# GUI executable
+qt5_wrap_ui(GUI_UI ${SRC_ROOT}/gui/mainwindow.ui)
+qt5_wrap_cpp(GUI_MOC ${SRC_ROOT}/gui/mainwindow.h)
+add_executable(weather_gui ${GUI_SOURCES} ${GUI_UI} ${GUI_MOC})
+target_link_libraries(weather_gui PRIVATE Qt5::Widgets)
+
 #用户配置文件
 file(COPY ${CMAKE_SOURCE_DIR}/configs/configUser.json
         DESTINATION ${CMAKE_BINARY_DIR}/configs)
@@ -113,8 +126,10 @@ file(COPY ${CMAKE_SOURCE_DIR}/configs/configUser.json
 file(COPY ${CMAKE_SOURCE_DIR}/configs/cache.json
         DESTINATION ${CMAKE_BINARY_DIR}/configs)
 #apiKey文件
-file(COPY ${CMAKE_SOURCE_DIR}/configs/configKey.json
-        DESTINATION ${CMAKE_BINARY_DIR}/configs)
+if(EXISTS ${CMAKE_SOURCE_DIR}/configs/configKey.json)
+    file(COPY ${CMAKE_SOURCE_DIR}/configs/configKey.json
+            DESTINATION ${CMAKE_BINARY_DIR}/configs)
+endif()
 
 #语言文件
 file(COPY ${SRC_ROOT}/cli/i18n/lang_zh.json

--- a/README.md
+++ b/README.md
@@ -1,0 +1,25 @@
+# Weather Forecast Application
+
+This project provides both a command line interface (CLI) and a Qt based graphical interface (GUI) for querying weather information.
+
+## Building
+
+```bash
+cmake -S . -B build
+cmake --build build
+```
+
+If `configs/configKey.json` is present it will be copied to the build directory. The file is ignored by Git because it usually contains API keys.
+
+## Running
+
+After building you will get two executables inside the `build` directory:
+
+- `weather_cli` – the traditional command line application
+- `weather_gui` – a simple window that wraps the CLI
+
+### Switching between CLI and GUI
+
+Use `weather_cli` when you prefer terminal commands. Launch `weather_gui` for a windowed interface that internally runs the same commands.
+
+Both executables use the same configuration files located under `build/configs`.

--- a/src/gui/main_gui.cpp
+++ b/src/gui/main_gui.cpp
@@ -1,0 +1,9 @@
+#include <QApplication>
+#include "mainwindow.h"
+
+int main(int argc, char *argv[]) {
+    QApplication app(argc, argv);
+    mainwindow w;
+    w.show();
+    return app.exec();
+}

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -5,13 +5,29 @@
 // You may need to build the project (run Qt uic code generator) to get "ui_mainwindow.h" resolved
 
 #include "mainwindow.h"
+#include "ui_mainwindow.h"
 
 // 初始化主窗口
 mainwindow::mainwindow(QWidget *parent) :
     QWidget(parent), ui(new Ui::mainwindow) {
-    ui->setupUi(this);    // 调用基类 QWidget 的构造函数，创建 UI 对象
+    ui->setupUi(this);
+    connect(&process, &QProcess::readyReadStandardOutput, this, &mainwindow::readOutput);
+    connect(ui->runButton, &QPushButton::clicked, this, &mainwindow::runCommand);
 }
 
 mainwindow::~mainwindow() {
+    process.kill();
+    process.waitForFinished();
     delete ui;
+}
+
+void mainwindow::runCommand() {
+    QString cmd = ui->commandEdit->text();
+    ui->outputEdit->clear();
+    QStringList args = cmd.split(' ', Qt::SkipEmptyParts);
+    process.start("./weather_cli", args);
+}
+
+void mainwindow::readOutput() {
+    ui->outputEdit->append(QString::fromUtf8(process.readAllStandardOutput()));
 }

--- a/src/gui/mainwindow.h
+++ b/src/gui/mainwindow.h
@@ -6,6 +6,7 @@
 #define MAINWINDOW_H
 
 #include <QWidget>
+#include <QProcess>
 
 
 QT_BEGIN_NAMESPACE
@@ -22,8 +23,13 @@ public:
     // override关键字确保正确覆盖基类虚函数
     ~mainwindow() override;
 
+private slots:
+    void runCommand();
+    void readOutput();
+
 private:
     Ui::mainwindow *ui;
+    QProcess process;
 };
 
 

--- a/src/gui/mainwindow.ui
+++ b/src/gui/mainwindow.ui
@@ -5,18 +5,25 @@
     <exportmacro/>
     <class>mainwindow</class>
     <widget class="QWidget" name="mainwindow">
-        <property name="geometry">
-            <rect>
-                <x>0</x>
-                <y>0</y>
-                <width>400</width>
-                <height>300</height>
-            </rect>
-        </property>
         <property name="windowTitle">
-            <string>mainwindow</string>
+            <string>Weather CLI GUI</string>
         </property>
+        <layout class="QVBoxLayout" name="verticalLayout">
+            <item>
+                <widget class="QLineEdit" name="commandEdit"/>
+            </item>
+            <item>
+                <widget class="QPushButton" name="runButton">
+                    <property name="text">
+                        <string>Run</string>
+                    </property>
+                </widget>
+            </item>
+            <item>
+                <widget class="QTextEdit" name="outputEdit"/>
+            </item>
+        </layout>
     </widget>
-    <pixmapfunction/>
+    <resources/>
     <connections/>
 </ui>


### PR DESCRIPTION
## Summary
- integrate Qt5 and add GUI build target
- provide a simple `mainwindow` with command entry and output display
- create new `main_gui.cpp` to launch the Qt window
- document how to build and switch between CLI and GUI
- gracefully handle missing `configKey.json` in CMake

## Testing
- `cmake -S . -B build` *(passes)*
- `cmake --build build` *(fails: fatal error: conio.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68557c5bbbcc832aa1c559d1ecded0a8