### PR TITLE
Fix Qt6 build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,11 +3,18 @@ cmake_minimum_required(VERSION 3.21)
 project(weatherForecast)
 # 设置当前项目的名称为 WeatherApp
 
+# Use C++20
 set(CMAKE_CXX_STANDARD 20)
-find_package(Qt5 COMPONENTS Widgets REQUIRED)
+
+# Enable Qt6 and its automatic tools
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTOUIC ON)
+set(CMAKE_AUTORCC ON)
+
+find_package(Qt6 COMPONENTS Widgets REQUIRED)
 # 设置 C++ 标准为 C++20
 
-set(CURL_PATH "F:\\CPlusDependences\\LibCurl\\V8")
+find_package(CURL REQUIRED)
 
 # 源码根目录
 set(SRC_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/src)
@@ -16,7 +23,7 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -static-libstdc++ -static-libgcc")
 
 # 包含头文件路径
 include_directories(
-        ${CURL_PATH}/include
+        ${CURL_INCLUDE_DIRS}
         ${SRC_ROOT}/core            # 天气核心模块路径
         ${SRC_ROOT}/gui             # GUI 模块路径
         ${SRC_ROOT}/utils           # 工具模块路径
@@ -24,8 +31,6 @@ include_directories(
         ${SRC_ROOT}/cli/i18n        # 国际化模块路径
         ${SRC_ROOT}/config
 )
-#引入CurlLib和bin
-link_directories(${CURL_PATH}/lib)
 # 源码文件（CLI 用）
 set(CLI_SOURCES
         ${SRC_ROOT}/cli/common/delay.cpp
@@ -96,28 +101,15 @@ set(WEATHER_GLOBAL
 # CLI 可执行文件
 add_executable(weather_cli ${WEATHER_GLOBAL} ${CLI_SOURCES})
 
-# 创建 CLI 可执行程序 weather_cli，包含上面定义的 CLI_SOURCES
-#将curl 连接到可执行文件
-
-target_link_libraries(weather_cli PRIVATE curl)
-
-#手动复制.dll 文件到指定目标
-if(WIN32)
-    set(CURL_DLL_PATH ${CURL_PATH}/bin/libcurl-x64.dll)
-
-    add_custom_command(TARGET weather_cli POST_BUILD
-            COMMAND ${CMAKE_COMMAND} -E copy_if_different
-            "${CURL_DLL_PATH}"
-            $<TARGET_FILE_DIR:weather_cli>
-            COMMENT "Copying libcurl.dll to output directory..."
-    )
-endif()
+# 链接 libcurl
+target_link_libraries(weather_cli PRIVATE CURL::libcurl)
 
 # GUI executable
-qt5_wrap_ui(GUI_UI ${SRC_ROOT}/gui/mainwindow.ui)
-qt5_wrap_cpp(GUI_MOC ${SRC_ROOT}/gui/mainwindow.h)
+qt6_wrap_ui(GUI_UI ${SRC_ROOT}/gui/mainwindow.ui)
+qt6_wrap_cpp(GUI_MOC ${SRC_ROOT}/gui/mainwindow.h)
 add_executable(weather_gui ${GUI_SOURCES} ${GUI_UI} ${GUI_MOC})
-target_link_libraries(weather_gui PRIVATE Qt5::Widgets)
+target_include_directories(weather_gui PRIVATE ${CMAKE_BINARY_DIR})
+target_link_libraries(weather_gui PRIVATE Qt6::Widgets)
 
 #用户配置文件
 file(COPY ${CMAKE_SOURCE_DIR}/configs/configUser.json

--- a/README.md
+++ b/README.md
@@ -9,6 +9,12 @@ cmake -S . -B build
 cmake --build build
 ```
 
+Qt 6 and libcurl development packages are required. On Debian/Ubuntu you can install them with:
+
+```bash
+sudo apt-get install qt6-base-dev libcurl4-openssl-dev
+```
+
 If `configs/configKey.json` is present it will be copied to the build directory. The file is ignored by Git because it usually contains API keys.
 
 ## Running

--- a/src/cli/common/cli_getch.h
+++ b/src/cli/common/cli_getch.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#ifdef _WIN32
+#include <conio.h>
+inline char cli_getch() {
+    return _getch();
+}
+#else
+#include <termios.h>
+#include <unistd.h>
+inline char cli_getch() {
+    struct termios oldt{}, newt{};
+    tcgetattr(STDIN_FILENO, &oldt);
+    newt = oldt;
+    newt.c_lflag &= ~(ICANON | ECHO);
+    tcsetattr(STDIN_FILENO, TCSANOW, &newt);
+    char ch;
+    ssize_t n = read(STDIN_FILENO, &ch, 1);
+    tcsetattr(STDIN_FILENO, TCSANOW, &oldt);
+    return n == 1 ? ch : '\n';
+}
+#endif

--- a/src/cli/display/date_display/cli_date_display.cpp
+++ b/src/cli/display/date_display/cli_date_display.cpp
@@ -4,7 +4,7 @@
 #include "cli_date_display.h"
 
 #include <iostream>
-#include <conio.h>
+#include "../../common/cli_getch.h"
 
 #include "../../../core/doubao_manager.h"
 #include "lunar_api.h"
@@ -108,7 +108,7 @@ void showCurrentDate(CliContext& ctx, bool showAll) {
 
         if (ctx.mode == CliMode::Interactive) {
             std::cout << ctx.i18n.tr("life_index", "prompt_refresh") << std::flush;
-            char ch = _getch();
+            char ch = cli_getch();
             if (ch == 'R' || ch == 'r') {
                 cache.clear("lunar_info");
                 continue;

--- a/src/cli/display/life_index/cli_life_index.cpp
+++ b/src/cli/display/life_index/cli_life_index.cpp
@@ -1,4 +1,4 @@
-#include <conio.h>
+#include "../../common/cli_getch.h"
 #include <iostream>
 
 #include "CacheManager.h"
@@ -51,7 +51,7 @@ void showLifeIndices(CliContext& cli) {
 
 
         std::cout << "\n" << i18n.tr("life_index", "prompt_refresh") << "\n";  // 翻译 "按 R 刷新数据，任意其他键返回主菜单..."
-        char ch = _getch();
+        char ch = cli_getch();
         if (ch == 'R' || ch == 'r') {
             result = manager.getLifeIndices(configUser.getCityId(), 0,cli.cache); // 设置过期时间为 0 强制刷新
         } else {

--- a/src/cli/display/update_city/cli_update_city.cpp
+++ b/src/cli/display/update_city/cli_update_city.cpp
@@ -1,4 +1,4 @@
-#include <conio.h>
+#include "../../common/cli_getch.h"
 #include <iostream>
 #include <curl/curl.h>
 
@@ -51,7 +51,7 @@ void showCityChoose(CliContext& cli) {
         // 输入提示
         std::cout << i18n.tr("searchCity", "input_hint") << keyword;  // 翻译 "输入城市关键字（输入 : 返回主菜单）"
 
-        char ch = _getch();
+        char ch = cli_getch();
         if (ch == ':' || keyword == ":") {
             std::cout << "\n" << i18n.tr("searchCity", "cancelled") << std::endl;  // 翻译 "已取消设置，返回主菜单"
             delay_ms(2000);

--- a/src/cli/display/weather_display/cli_weather_display.cpp
+++ b/src/cli/display/weather_display/cli_weather_display.cpp
@@ -4,7 +4,7 @@
 
 #include "cli_weather_display.h"
 
-#include <conio.h>
+#include "../common/cli_getch.h"
 #include <iostream>
 
 #include "config_context.h"
@@ -41,7 +41,7 @@ void showWeatherForecast(CliContext& cli, const std::string& unit) {
     while (true) {
         displayWeather(result, i18n, configUser, unit);
         std::cout << "\n" << i18n.tr("forecast", "prompt_refresh") << "\n";  // 翻译 "prompt_refresh"
-        char ch = _getch();
+        char ch = cli_getch();
         if (ch == 'R' || ch == 'r') {
             result = manager.get7DayForecast(
                 configUser.getCityId(),

--- a/src/cli/i18n/i18n_loader.cpp
+++ b/src/cli/i18n/i18n_loader.cpp
@@ -1,7 +1,13 @@
  #include "i18n_loader.h"
 #include <fstream>
 #include <iostream>
+#ifdef _WIN32
 #include <direct.h>
+#define GETCWD _getcwd
+#else
+#include <unistd.h>
+#define GETCWD getcwd
+#endif
 #include <json.hpp>
 
 using json = nlohmann::json;
@@ -16,7 +22,7 @@ bool I18n::load(const std::string& language) {
 
     if (!file.is_open()) {
         char cwd[1024];
-        _getcwd(cwd, sizeof(cwd));
+        GETCWD(cwd, sizeof(cwd));
         std::cerr << "❌ 无法打开语言文件: " << path << std::endl;
         std::cerr << "📂 当前工作目录: " << cwd << std::endl;
         return false;


### PR DESCRIPTION
## Summary
- switch project to use Qt6
- add libcurl discovery instead of hardcoded paths
- add cross-platform `cli_getch` helper and fix Windows-only bits
- document Qt6 and libcurl in README

## Testing
- `cmake -S . -B build`
- `cmake --build build -j $(nproc)`
- `./build/weather_cli --help` (fails without config but runs)


------
https://chatgpt.com/codex/tasks/task_e_68568284e124832a8e25bf947de53e2a